### PR TITLE
replacing json.dumps with flask jsonify helper wrapper

### DIFF
--- a/Jann/app.py
+++ b/Jann/app.py
@@ -91,7 +91,7 @@ def model_reply():
         resp = {'fulfillmentText': 'None'}
 
     # return the response in a json object
-    return json.dumps(resp)
+    return jsonify(resp)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi Kory,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for using `json.dumps()` instead of flask `jsonify()`. You might have overlooked this one (since there is already one call to `jsonify()` at app.py:47). 

I see another potential issue at app.py:41. Instead of hardcoding the `SECRET_KEY` configuration, you may want to use this pattern: `SECRET_KEY=os.getenv("SECRET_KEY")` and add the key to the environment variables. I left this out of the PR to keep things simple. 

Lastly, Bento complains about the use of insecure `eval()` function. You can easily replace it with `ast.literal_eval()`. 

Hopefully, this is useful feedback. If you want to take a look at it yourself,  feel free download and give Bento a try (https://bento.dev).